### PR TITLE
Fixed Card Links: Issue #53

### DIFF
--- a/src/fragments/Grid/index.js
+++ b/src/fragments/Grid/index.js
@@ -146,7 +146,10 @@ export default class Grid extends React.Component {
       return false
     }).map((example, i) => {
       // get first link
-      const codeLink = (Array.isArray(example.code)) ? example.code[0] : example.code
+      let codeLink = (Array.isArray(example.code)) ? example.code[0] : example.code
+      if (!codeLink) {
+        codeLink = example.url;
+      }
       return (
         <Card key={i} className={styles.item}>
           <div className={styles.itemTitle}>


### PR DESCRIPTION
If the `code` field for an example is empty in `examples.json`, the card for that example has an an empty `href` attribute, which leads to a redirect to the same page on clicking the card.
This PR fixes the issue. If the `code` field is empty, the `url` field is used to redirect to the Github Repository for the example.